### PR TITLE
Default to http://localhost/parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var api = new ParseServer({
   javascriptKey: process.env.JAVASCRIPT_KEY || 'javascriptKey',
   push: pushConfig,
   filesAdapter: filesAdapter,
-  serverURL: process.env.SERVER_URL  // needed for Parse Cloud and push notifications
+  serverURL: process.env.SERVER_URL || 'http://localhost/parse'  // needed for Parse Cloud and push notifications
 });
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server
 // If you wish you require them, you can set them as options in the initialization above:


### PR DESCRIPTION
For cloud instances.

This needs to be http://localhost:1337/parse on local dev otherwise.
